### PR TITLE
fix, test: bcrypt compare await error and invalid credentials test

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,7 @@ export default function createApp(storage){
     const credentials = decodeCredentials(request.headers.authorization);
     const user = await storage.getUserByLogin(credentials.login); 
     
-    if(!user || await !bcrypt.compare(credentials.password, user.password)){
+    if(!user || !(await bcrypt.compare(credentials.password, user.password))){
       return response.status(401).send('Unauthorized');
     }
 

--- a/login.test.js
+++ b/login.test.js
@@ -15,7 +15,27 @@ describe('POST /login', () => {
             .expect('WWW-Authenticate', 'Basic realm="simple"');
     });
 
-    it.todo('should return 401 when credentials are invalid');
+    it('should return 401 when credentials are invalid', async () => {
+        const hashedPassword = await bcrypt.hash('correctPassword', 10);
+        
+        const storageStub = {
+            getUserByLogin: jest
+                .fn()
+                .mockResolvedValue({ id: 'user-id', login: 'user', password: hashedPassword }),
+        };
+
+        const app = createApp(storageStub);
+
+        const credentials = Buffer
+            .from('user:wrongPassword')
+            .toString('base64');
+
+        await request(app)
+            .post('/login')
+            .set('Authorization', `Basic ${credentials}`)
+            .expect(401);
+    });
+
     it.todo('should return 400 when authorization header is malformed');
 
     it('should return 200 with api key when Authorization header is valid', async () => {


### PR DESCRIPTION
This pull request improves authentication logic and testing for the login endpoint. The most important changes are a fix to the password comparison logic in the authentication flow and the addition of a new test to ensure invalid credentials are handled correctly.

Authentication logic fix:

* Corrected the logic in the password comparison check within `createApp` to ensure the result of `bcrypt.compare` is properly awaited and evaluated.

Testing improvements:

* Implemented a test case for the login endpoint that verifies a `401 Unauthorized` response is returned when invalid credentials are provided, replacing the previous placeholder.